### PR TITLE
Refactor plugin config for lolcommits v0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ cache: bundler
 rvm:
  - 2.0.0
  - 2.1.10
- - 2.2.8
- - 2.3.5
- - 2.4.2
+ - 2.2.9
+ - 2.3.6
+ - 2.4.3
+ - 2.5.0
  - ruby-head
 
 before_install:
- - gem install bundler -v 1.13.7
+ - gem update --system
  - git --version
  - git config --global user.email "lol@commits.org"
  - git config --global user.name "Lolcommits"

--- a/lib/lolcommits/plugin/slack.rb
+++ b/lib/lolcommits/plugin/slack.rb
@@ -11,17 +11,6 @@ module Lolcommits
       RETRY_COUNT = 2
 
       ##
-      # Returns the name of the plugin.
-      #
-      # Identifies the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'slack'
-      end
-
-      ##
       # Returns position(s) of when this plugin should run during the capture
       # process.
       #
@@ -52,11 +41,11 @@ module Lolcommits
           response = RestClient.post(
             ENDPOINT_URL,
             file: File.new(runner.main_image),
-            token: configuration['access_token'],
+            token: configuration[:access_token],
             filetype: 'jpg',
             filename: runner.sha,
             title: runner.message + "[#{runner.vcs_info.repo}]",
-            channels: configuration['channels']
+            channels: configuration[:channels]
           )
 
           debug response
@@ -86,7 +75,7 @@ module Lolcommits
       def configure_options!
         options = super
 
-        if options['enabled']
+        if options[:enabled]
           print "open the url below and issue a token for your user:\n"
           print "https://api.slack.com/custom-integrations/legacy-tokens\n"
           print "enter the generated token below, then press enter: (e.g. xxxx-xxxxxxxxx-xxxx) \n"
@@ -97,23 +86,12 @@ module Lolcommits
           channels = parse_user_input(gets.strip)
 
           options.merge!(
-            'access_token' => code,
-            'channels'     => channels
+            access_token: code,
+            channels: channels
           )
         end
 
         options
-      end
-
-      ##
-      # Returns true/false indicating if the plugin has been configured.
-      #
-      # Checks the `access_token` ond `channels` options have been set.
-      #
-      # @return [Boolean] true/false
-      #
-      def configured?
-        !configuration['access_token'].nil? && !configuration['channels'].nil?
       end
     end
   end

--- a/lib/lolcommits/slack/version.rb
+++ b/lib/lolcommits/slack/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Slack
-    VERSION = "0.0.2".freeze
+    VERSION = "0.0.3".freeze
   end
 end

--- a/lolcommits-slack.gemspec
+++ b/lolcommits-slack.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rest-client"
 
-  spec.add_development_dependency "lolcommits", "~> 0.9.6"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/test/lolcommits/plugin/slack_test.rb
+++ b/test/lolcommits/plugin/slack_test.rb
@@ -5,14 +5,6 @@ describe Lolcommits::Plugin::Slack do
   include Lolcommits::TestHelpers::GitRepo
   include Lolcommits::TestHelpers::FakeIO
 
-  def plugin_name
-    'slack'
-  end
-
-  it 'should have a name' do
-    ::Lolcommits::Plugin::Slack.name.must_equal plugin_name
-  end
-
   it 'should run on pre_capture and capture_ready' do
     ::Lolcommits::Plugin::Slack.runner_order.must_equal [:capture_ready]
   end
@@ -20,9 +12,8 @@ describe Lolcommits::Plugin::Slack do
   describe 'with a runner' do
 
     def runner
-      # a simple lolcommits runner with an empty configuration Hash
+      # a simple lolcommits runner
       @_runner ||= Lolcommits::Runner.new(
-        config: OpenStruct.new(read_configuration: {}),
         main_image: Tempfile.new('test_image')
       )
     end
@@ -32,22 +23,11 @@ describe Lolcommits::Plugin::Slack do
     end
 
     def valid_enabled_config
-      @_config ||= OpenStruct.new(
-        read_configuration: {
-          plugin.class.name => {
-            'enabled'      => true,
-            'access_token' => 'acbd-1234-wxyz-5678',
-            'channels'     => 'c123,c456'
-          }
-        }
-      )
-    end
-
-    describe 'initalizing' do
-      it 'should assign runner and an enabled option' do
-        plugin.runner.must_equal runner
-        plugin.options.must_equal ['enabled']
-      end
+      {
+        enabled: true,
+        access_token: 'acbd-1234-wxyz-5678',
+        channels: 'c123,c456'
+      }
     end
 
     describe '#run_capture_ready' do
@@ -58,7 +38,7 @@ describe Lolcommits::Plugin::Slack do
       it 'should post the message to slack' do
         stub_request(:any, plugin.class::ENDPOINT_URL)
         in_repo do
-          plugin.config = valid_enabled_config
+          plugin.configuration = valid_enabled_config
           output = fake_io_capture { plugin.run_capture_ready }
           assert_equal output, "Posting to Slack ... done!\n"
 
@@ -71,7 +51,7 @@ describe Lolcommits::Plugin::Slack do
       it 'should retry (and explain) if there is a failure (req timeout)' do
         in_repo do
           stub_request(:any, plugin.class::ENDPOINT_URL).to_timeout
-          plugin.config = valid_enabled_config
+          plugin.configuration = valid_enabled_config
 
           Proc.new { plugin.run_capture_ready }.
             must_output("Posting to Slack ... failed! Timed out connecting to server - retrying ...\nPosting to Slack ... failed! Timed out connecting to server - giving up ...\nTry running config again:\n\tlolcommits --config -p slack\n")
@@ -87,20 +67,16 @@ describe Lolcommits::Plugin::Slack do
 
     describe '#enabled?' do
       it 'should be false by default' do
-        plugin.enabled?.must_equal false
+        assert_nil plugin.enabled?
       end
 
       it 'should true when configured' do
-        plugin.config = valid_enabled_config
+        plugin.configuration = valid_enabled_config
         plugin.enabled?.must_equal true
       end
     end
 
     describe 'configuration' do
-      it 'should not be configured by default' do
-        plugin.configured?.must_equal false
-      end
-
       it 'should allow plugin options to be configured' do
         configured_plugin_options = {}
 
@@ -108,16 +84,11 @@ describe Lolcommits::Plugin::Slack do
           configured_plugin_options = plugin.configure_options!
         end
 
-        configured_plugin_options.must_equal( {
-          "enabled"      => true,
-          "access_token" => 'abc-def',
-          "channels"     => 'c1,c3,c4'
+        configured_plugin_options.must_equal({
+          enabled: true,
+          access_token: 'abc-def',
+          channels: 'c1,c3,c4'
         })
-      end
-
-      it 'should indicate when configured' do
-        plugin.config = valid_enabled_config
-        plugin.configured?.must_equal true
       end
 
       describe '#valid_configuration?' do
@@ -126,7 +97,7 @@ describe Lolcommits::Plugin::Slack do
         end
 
         it 'should be true for a valid configuration' do
-          plugin.config = valid_enabled_config
+          plugin.configuration = valid_enabled_config
           plugin.valid_configuration?.must_equal true
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,9 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-# necessary libs from lolcommits (allowing plugin to run)
-require 'git'
-require 'lolcommits/runner'
-require 'lolcommits/vcs_info'
-require 'lolcommits/backends/git_info'
+# lolcommits gem
+require 'lolcommits'
 
-# lolcommit test helpers
-require 'webmock/minitest'
+# lolcommits test helpers
 require 'lolcommits/test_helpers/git_repo'
 require 'lolcommits/test_helpers/fake_io'
 
@@ -16,6 +12,7 @@ if ENV['COVERAGE']
 end
 
 # plugin gem test libs
+require 'webmock/minitest'
 require 'lolcommits/plugin/slack'
 require 'minitest/autorun'
 


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* update rubies for Travis CI
* bump gem version (for new plugin release)