### PR TITLE
Switch from files.upload API to new multi-step uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ webcam every time you git commit code, and archives a lolcat style image
 with it. Git blame has never been so much fun!
 
 This plugin automatically posts your lolcommits to one (or more)
-[Slack](https://slack.com) channels.
+[Slack](https://slack.com) channels using Slack's modern [file upload
+API](https://docs.slack.dev/messaging/working-with-files).
 
 The Slack post will contain the git commit message and repo name. The
-SHA is used as the uploaded file name. Posting will be retried (once)
-should any error occur.
+SHA is used as the uploaded file name. Each upload step will be retried
+(twice) should any error occur.
 
 ## Requirements
 


### PR DESCRIPTION
# Brief

On November 12th, 2025, Slack completely discontinued the `files.upload` API endpoint which powers this lolcommits plugin. This PR switches to the new set of file uploading API endpoints, which is a multi-step process involving the generation of a transient upload URL with `files.getUploadURLExternal`, POSTing the file content to the URL, then completing the upload and sharing to channels with the `files.completeUploadExternal` endpoint.

Fixes #9 

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [X] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [X] If relevant, mention GitHub issue number above and include in a commit message.
- [X] Latest code from master merged.
- [X] New behaviour has test coverage.
- [X] Avoid duplicating code.
- [X] No commented out code.
- [X] Avoid comments for your code, write code that explains itself.
- [X] Changes are simple, useful, clear and brief.
